### PR TITLE
fix: Too few arguments to function Filament\Actions\StaticAction::submit

### DIFF
--- a/src/Components/TableView.php
+++ b/src/Components/TableView.php
@@ -142,7 +142,7 @@ class TableView extends Component
         return StaticAction::make('export')
             ->button()
             ->label(__('filament-export::table_view.export_action_label'))
-            ->submit()
+            ->submit(null)
             ->icon(config('filament-export.export_icon'));
     }
 


### PR DESCRIPTION
fix: Too few arguments to function Filament\Actions\StaticAction::submit(), 0 passed in D:\laragon\www\form-builder\vendor\alperenersoy\filament-export\src\Components\TableView.php on line 145 and exactly 1 expected

This bug in response export.

I also tried in https://demo.larazeus.com/admin/responses/report?form_id=1 and there is a server error